### PR TITLE
added safety net for improved compatibility with Nimble mod

### DIFF
--- a/patchnotes.txt
+++ b/patchnotes.txt
@@ -1,3 +1,4 @@
 - Boulder Trap: damage upgrade +5 > +7, "triggered x times" wording on the in-combat hint reworded to either "not ready yet" or "ready"
 - Energy icon on text now has a little border around it so it looks a little less weird
 - Bugfix: Together in Spire no longer crashes when you launch a singleplayer run
+- Bugfix: Traps now trigger correctly with the Nimble mod, and possibly fix other mod incompatibilities with traps (courtesy of Sagil)

--- a/src/main/java/bogwarden/patches/TrapPatches.java
+++ b/src/main/java/bogwarden/patches/TrapPatches.java
@@ -16,19 +16,13 @@ import static bogwarden.util.Wiz.*;
 
 public class TrapPatches {
     private static boolean triggeredThisDamage = false;
+    private static DamageInfo info;
 
     @SpirePatch(clz=AbstractPlayer.class, method="damage")
     public static class TriggerOnDamage {
-        public static void Prefix() {
+        public static void Prefix(AbstractPlayer __instance, DamageInfo info) {
             triggeredThisDamage = false;
-        }
-
-        @SpireInsertPatch(rloc=101)
-        public static void Insert(AbstractPlayer __instance, DamageInfo info) {
-            if (!triggeredThisDamage) {
-                triggeredThisDamage = true;
-                att(new TriggerTrapAction(info.owner));
-            }
+            TrapPatches.info = info;
         }
     }
 
@@ -38,7 +32,7 @@ public class TrapPatches {
         public static void Prefix(AbstractPlayer __instance) {
             if (!triggeredThisDamage) {
                 triggeredThisDamage = true;
-                att(new TriggerTrapAction(null));
+                att(new TriggerTrapAction(info.owner));
             }
         }
     }

--- a/src/main/java/bogwarden/patches/TrapPatches.java
+++ b/src/main/java/bogwarden/patches/TrapPatches.java
@@ -32,7 +32,17 @@ public class TrapPatches {
         }
     }
 
-    
+    // safety net for cross-mod compatibility
+    @SpirePatch(clz=AbstractPlayer.class, method="updateCardsOnDamage")
+    public static class TriggerOnUpdateCardsOnDamage {
+        public static void Prefix(AbstractPlayer __instance) {
+            if (!triggeredThisDamage) {
+                triggeredThisDamage = true;
+                att(new TriggerTrapAction(null));
+            }
+        }
+    }
+
     @SpirePatch(clz=PlayerDamage.class, method="Insert", paramtypez={AbstractCreature.class, DamageInfo.class, int[].class, boolean[].class})
     public static class TriggerOnTempHPLoss {
         @SpireInsertPatch(locator=Locator.class)


### PR DESCRIPTION
Also triggers traps when AbstractPlayer.updateCardsOnDamage is called. This only has an effect if the normal triggers are bypassed by other mods.